### PR TITLE
Move releases to PowerForge automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       checks: read
       contents: write
       pull-requests: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@PowerForge-v1.0.2
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@e88d91b6c4e7347b8daadbbc54428a6191bddb7a # PowerForge-v1.0.2 with receiver trust hardening
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,71 +1,36 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  pull_request:
+    types: [closed]
   workflow_dispatch:
-
-permissions:
-  contents: write
+    inputs:
+      pr_number:
+        description: Merged pull request number to release or recover
+        required: true
+        type: number
+      merge_commit_sha:
+        description: Expected merge commit SHA
+        required: false
+        type: string
+      increment:
+        description: auto, none, patch, minor, or major
+        required: false
+        default: auto
+        type: string
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Test
-        run: npm test
-
-      - name: Type check
-        run: npm run check
-
-      - name: Pack release payload
-        run: npm run pack
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: lawn-mower-card-release
-          path: release/
-
-  publish:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Pack release payload
-        run: npm run pack
-
-      - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            release/lawn-mower-card.js
-            release/README.md
-            release/hacs.json
-            release/LICENSE
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: read
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@PowerForge-v1.0.2
+    with:
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}
+      default_branch: ${{ github.event.repository.default_branch }}
+      increment: ${{ inputs.increment || 'auto' }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -374,12 +374,15 @@ side.
 
 ## Releases
 
-Version tags in the `vX.Y.Z` format trigger the release workflow. Each tagged
-release rebuilds the card, packages the release payload, and attaches
-`lawn-mower-card.js`, `README.md`, `hacs.json`, and `LICENSE` to the GitHub
-release so frontend users have a clean downloadable artifact. You can also run
-the workflow manually to verify the packaging step without publishing a
-release.
+Merged pull requests drive releases. Add one release label before merging when
+the default policy is not enough: `release:none`, `release:patch`,
+`release:minor`, or `release:major`. PowerForge updates the package metadata,
+runs the repository tests and type check, packages `lawn-mower-card.js`, and
+publishes the matching GitHub release from the prepared version commit.
+
+The Release workflow can also recover a merged pull request. Run it manually
+with the pull request number and, when available, its merge commit SHA; leave
+the increment on `auto` unless the original label decision must be overridden.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- replace the repository-specific tag build and publish jobs with the thin PowerForge receiver
- use a trusted closed-PR trigger so fork and Dependabot merges can release
- pin the shared workflow to the immutable reviewed PowerForge commit
- retain test, type-check, package, and HACS asset publication through the shared release flow
- document the merged-PR labels and manual recovery path