### PR TITLE
Pin release automation to PowerForge 1.0.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,11 @@ jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     permissions:
+      actions: read
       checks: read
       contents: write
       pull-requests: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@e88d91b6c4e7347b8daadbbc54428a6191bddb7a # PowerForge-v1.0.2 with receiver trust hardening
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@93386bdc88f3b3d2d591fffd3a22ca2289097e38 # PowerForge-v1.0.3 immutable release workflow
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}


### PR DESCRIPTION
## Summary

- grant the reusable release workflow read access to GitHub Actions run metadata
- pin the thin receiver to the final immutable PowerForge 1.0.3 workflow revision
- keep all release, versioning, artifact, and recovery logic in PowerForge

## Validation

- the pinned revision resolves to the maintained PowerForge reusable workflow
- that workflow pins its nested action to the immutable PowerForge 1.0.3 release commit
- no integration or card runtime code changes

This maintenance PR is labeled release:none so merging it does not create a product release.