### PR TITLE
Fix summary chip centering across card layouts

### DIFF
--- a/lawn-mower-card.js
+++ b/lawn-mower-card.js
@@ -26,8 +26,8 @@ var Gn=Object.defineProperty;var Xn=Object.getOwnPropertyDescriptor;var b=(t,n,e
       ${i.icon?d`<ha-icon .icon=${i.icon} aria-hidden="true"></ha-icon>`:l}<span>${i.label}</span>
     </button>`)}</div>${e||l}
   </section>`:l}var Yi=y`
-  .custom-summary { display:flex; flex-wrap:wrap; gap:8px; min-width:0; }
-  .custom-chip { display:flex; align-items:center; gap:6px; padding:6px 10px; border:1px solid var(--mower-border,var(--divider-color)); border-radius:18px; background:var(--mower-surface,var(--secondary-background-color)); font-size:12px; min-width:0; max-width:100%; color:var(--mower-muted,var(--secondary-text-color)); overflow-wrap:anywhere; }
+  .custom-summary { display:flex; flex-wrap:wrap; justify-content:center; gap:8px; min-width:0; }
+  .custom-chip { box-sizing:border-box; display:flex; align-items:center; gap:6px; padding:6px 10px; border:1px solid var(--mower-border,var(--divider-color)); border-radius:18px; background:var(--mower-surface,var(--secondary-background-color)); font-size:12px; min-width:0; max-width:100%; color:var(--mower-muted,var(--secondary-text-color)); overflow-wrap:anywhere; }
   .custom-chip strong { color:var(--mower-text,var(--primary-text-color)); font-weight:600; }
   .custom-chip ha-icon { --mdc-icon-size:16px; flex:none; }
   .custom-tiles { --custom-tile-gap:10px; display:grid; grid-template-columns:repeat(var(--custom-columns,auto-fit),minmax(min(140px,100%),1fr)); gap:var(--custom-tile-gap); min-width:0; }
@@ -2561,11 +2561,11 @@ var Gn=Object.defineProperty;var Xn=Object.getOwnPropertyDescriptor;var b=(t,n,e
               <div class="title-block">
                 <div class="title">${i}</div>
                 <div class="subtitle">${a}</div>
-                ${ne(f)}
               </div>
               <div class=${`state-pill state-${e.state}`}>${this._friendlyMowerState(e.state)}</div>
             </div>
 
+            ${ne(f)}
             ${c?d`
                   <div class="map">
                     ${P(r?.attributes.mowing_map_api_path)?d`<lawn-mower-mowing-map style="height:320px"

--- a/src/customization-view.ts
+++ b/src/customization-view.ts
@@ -28,8 +28,8 @@ export function renderCustomActions(actions: DisplayAction[], title: string, con
 }
 
 export const customizationStyles = css`
-  .custom-summary { display:flex; flex-wrap:wrap; gap:8px; min-width:0; }
-  .custom-chip { display:flex; align-items:center; gap:6px; padding:6px 10px; border:1px solid var(--mower-border,var(--divider-color)); border-radius:18px; background:var(--mower-surface,var(--secondary-background-color)); font-size:12px; min-width:0; max-width:100%; color:var(--mower-muted,var(--secondary-text-color)); overflow-wrap:anywhere; }
+  .custom-summary { display:flex; flex-wrap:wrap; justify-content:center; gap:8px; min-width:0; }
+  .custom-chip { box-sizing:border-box; display:flex; align-items:center; gap:6px; padding:6px 10px; border:1px solid var(--mower-border,var(--divider-color)); border-radius:18px; background:var(--mower-surface,var(--secondary-background-color)); font-size:12px; min-width:0; max-width:100%; color:var(--mower-muted,var(--secondary-text-color)); overflow-wrap:anywhere; }
   .custom-chip strong { color:var(--mower-text,var(--primary-text-color)); font-weight:600; }
   .custom-chip ha-icon { --mdc-icon-size:16px; flex:none; }
   .custom-tiles { --custom-tile-gap:10px; display:grid; grid-template-columns:repeat(var(--custom-columns,auto-fit),minmax(min(140px,100%),1fr)); gap:var(--custom-tile-gap); min-width:0; }

--- a/src/lawn-mower-card.ts
+++ b/src/lawn-mower-card.ts
@@ -487,11 +487,11 @@ export class LawnMowerCard extends LitElement {
               <div class="title-block">
                 <div class="title">${title}</div>
                 <div class="subtitle">${subtitle}</div>
-                ${renderSummary(headerSummary)}
               </div>
               <div class=${`state-pill state-${mower.state}`}>${this._friendlyMowerState(mower.state)}</div>
             </div>
 
+            ${renderSummary(headerSummary)}
             ${showMap
               ? html`
                   <div class="map">


### PR DESCRIPTION
Custom summary chips now center across cinematic, dashboard, classic, compact, and wide layouts, including wrapped rows. Classic layouts give the summary its own full-width row below the title and state; long chips keep their padding and borders within the available width.

This fixes the remaining summary alignment reported in [EvotecIT/homeassistant-dreamelawnmower#187](https://github.com/EvotecIT/homeassistant-dreamelawnmower/issues/187). The Lovelace card owns this rendering; the integration needs no code change. Users will need a card release containing this fix.

Validation: build, TypeScript check, and all 134 tests passed. Browser checks covered five layouts at four widths (320–1080 px), empty/single/multiple/wrapped summaries, long labels, and representative light/dark views. Independent local review found no actionable issues. The checked-in JavaScript bundle was regenerated.
